### PR TITLE
Fixing axiom completeness

### DIFF
--- a/attributions.ipynb
+++ b/attributions.ipynb
@@ -66,7 +66,7 @@
     "     for a given label.\n",
     "  '''\n",
     "  lab_index = np.where(np.in1d(labels, [label]))[0][0]\n",
-    "  t_softmax = tf.reduce_mean(T('softmax2'), reduction_indices=0)\n",
+    "  t_softmax = tf.reduce_sum(T('softmax2'), reduction_indices=0)\n",
     "  return t_softmax[lab_index]\n",
     "\n",
     "def gradients(img, label):\n",


### PR DESCRIPTION
If we take reduce_mean in this function, the axiom completeness is no longer true.
We miss the true value by a factor equal to number of steps.
Use reduce_sum() instead.