### PR TITLE
Update integrated_gradients signature to match docstring

### DIFF
--- a/IntegratedGradients/integrated_gradients.py
+++ b/IntegratedGradients/integrated_gradients.py
@@ -4,7 +4,7 @@ def integrated_gradients(
     inp, 
     target_label_index,
     predictions_and_gradients,
-    baseline,
+    baseline=None,
     steps=50):
   """Computes integrated gradients for a given network and prediction label.
 


### PR DESCRIPTION
The docstring specifies that the `baseline` param in `integrated_gradients` should have a default value of `None`, but this is currently not specified in the signature.