### PR TITLE
Using Trapezoidal Rule Instead of Left Riemann Sum

### DIFF
--- a/IntegratedGradients/integrated_gradients.py
+++ b/IntegratedGradients/integrated_gradients.py
@@ -78,7 +78,11 @@ def integrated_gradients(
   scaled_inputs = [baseline + (float(i)/steps)*(inp-baseline) for i in range(0, steps+1)]
   predictions, grads = predictions_and_gradients(scaled_inputs, target_label_index)  # shapes: <steps+1>, <steps+1, inp.shape>
   
-  avg_grads = np.average(grads[:-1], axis=0)
+  # Use trapezoidal rule to approximate the integral (see Section 4 in
+  # https://arxiv.org/abs/1908.06214 for an accuracy comparison between left,
+  # right, and trapezoidal IG approximations).
+  grads = (grads[:-1] + grads[1:]) / 2.0
+  avg_grads = np.average(grads, axis=0)
   integrated_gradients = (inp-baseline)*avg_grads  # shape: <inp.shape>
   return integrated_gradients, predictions
 

--- a/IntegratedGradients/integrated_gradients.py
+++ b/IntegratedGradients/integrated_gradients.py
@@ -78,9 +78,11 @@ def integrated_gradients(
   scaled_inputs = [baseline + (float(i)/steps)*(inp-baseline) for i in range(0, steps+1)]
   predictions, grads = predictions_and_gradients(scaled_inputs, target_label_index)  # shapes: <steps+1>, <steps+1, inp.shape>
   
-  # Use trapezoidal rule to approximate the integral (see Section 4 in
-  # https://arxiv.org/abs/1908.06214 for an accuracy comparison between left,
-  # right, and trapezoidal IG approximations).
+  # Use trapezoidal rule to approximate the integral.
+  # See Section 4 of the following paper for an accuracy comparison between
+  # left, right, and trapezoidal IG approximations:
+  # "Computing Linear Restrictions of Neural Networks", Matthew Sotoudeh, Aditya V. Thakur
+  # https://arxiv.org/abs/1908.06214
   grads = (grads[:-1] + grads[1:]) / 2.0
   avg_grads = np.average(grads, axis=0)
   integrated_gradients = (inp-baseline)*avg_grads  # shape: <inp.shape>


### PR DESCRIPTION
Hello! In our preprint (https://arxiv.org/abs/1908.06214) we have compared (Section 4, Table 2) the accuracy of different integral approximation methods for approximating IG, and found that using the trapezoidal rule instead of a left-Riemann sum can lead to significant accuracy improvement. This PR makes that change in `integrated_gradients.py`, along with a comment for justification. We talked with Mukund about this a few months ago about this.